### PR TITLE
Minor nits

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config/Cargo.toml
+++ b/nixos/modules/installer/tools/nixos-generate-config/Cargo.toml
@@ -8,4 +8,4 @@ simple-error = "0.2"
 
 [[bin]]
 name = "nixos-generate-config"
-path = "src/bin/main.rs"
+path = "src/main.rs"

--- a/nixos/modules/installer/tools/nixos-generate-config/src/bin/main.rs
+++ b/nixos/modules/installer/tools/nixos-generate-config/src/bin/main.rs
@@ -1,8 +1,0 @@
-use nixos_generate_config::run_app;
-use std::env;
-use std::process::exit;
-
-pub fn main() {
-    let args: Vec<_> = env::args().collect();
-    exit(run_app(&args))
-}

--- a/nixos/modules/installer/tools/nixos-generate-config/src/lib.rs
+++ b/nixos/modules/installer/tools/nixos-generate-config/src/lib.rs
@@ -82,20 +82,19 @@ fn parse_options(args: &[String]) -> Result<Options> {
     }
 }
 
-fn show_help(app_name: &str) -> Result<()> {
+fn show_help() -> Result<()> {
     let status = try_with!(
         Command::new(MAN_EXECUTABLE)
             .arg("nixos-generate-config")
             .env("MANPATH", NIXOS_MANPAGES)
             .status(),
-        "{}: failed to open man page",
-        app_name
+        "failed to open man page"
     );
 
     match status.code() {
         Some(0) => Ok(()),
-        Some(code) => bail!("{}: man exited with {}", app_name, code),
-        None => bail!("{}: man was killed by signal", app_name),
+        Some(code) => bail!("man exited with {}", code),
+        None => bail!("man was killed by signal"),
     }
 }
 
@@ -113,7 +112,7 @@ pub fn run_app(args: &[String]) -> i32 {
     };
 
     if opts.show_help {
-        if let Err(err) = show_help(app_name) {
+        if let Err(err) = show_help() {
             writeln!(io::stderr(), "{}: {}", app_name, err)
                 .expect("Failed to write error to stderr");
 

--- a/nixos/modules/installer/tools/nixos-generate-config/src/lib.rs
+++ b/nixos/modules/installer/tools/nixos-generate-config/src/lib.rs
@@ -1,15 +1,14 @@
-#[macro_use]
-extern crate simple_error;
-
 use std::error;
-use std::result;
-use std::string::String;
+use std::io;
+use std::io::Write;
 use std::process::Command;
+
+use simple_error::{bail, try_with};
 
 const MAN_EXECUTABLE: &str = env!("MAN_EXECUTABLE");
 const NIXOS_MANPAGES: &str = env!("NIXOS_MANPAGES");
 
-type Result<T> = result::Result<T,Box<dyn error::Error>>;
+type Result<T> = std::result::Result<T, Box<dyn error::Error>>;
 
 struct Options {
     out_dir: String,
@@ -17,7 +16,7 @@ struct Options {
     force: bool,
     no_filesystems: bool,
     show_hardware_config: bool,
-    show_help: bool
+    show_help: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -26,7 +25,7 @@ pub struct Error {
 }
 
 fn parse_options(args: &[String]) -> Result<Options> {
-    let mut i : usize = 0;
+    let mut i: usize = 0;
     let mut opts = Options {
         out_dir: String::from("/etc/nixos"),
         root_dir: String::from("/"),
@@ -35,27 +34,34 @@ fn parse_options(args: &[String]) -> Result<Options> {
         show_hardware_config: false,
         show_help: false,
     };
+
     loop {
         if i >= args.len() {
-            return Ok(opts)
+            return Ok(opts);
         }
+
         match args[i].as_ref() {
-            "-h"|"--help" => {
+            "-h" | "--help" => {
                 opts.show_help = true;
-                return Ok(opts)
+
+                return Ok(opts);
             }
             "--dir" => {
                 i += 1;
+
                 if i >= args.len() {
                     bail!("'--dir' requires an argument");
                 }
+
                 opts.out_dir = args[i].clone();
             }
             "--root" => {
                 i += 1;
+
                 if i >= args.len() {
                     bail!("'--root' requires an argument");
                 }
+
                 opts.root_dir = args[i].clone();
             }
             "--force" => {
@@ -71,44 +77,49 @@ fn parse_options(args: &[String]) -> Result<Options> {
                 bail!("unrecognized argument '{}'", args[i]);
             }
         }
+
         i += 1;
     }
 }
 
 fn show_help(app_name: &str) -> Result<()> {
-    let status = try_with!(Command::new(MAN_EXECUTABLE)
-        .arg("nixos-generate-config")
-        .env("MANPATH", NIXOS_MANPAGES)
-        .status(), "{}: failed to open man page", app_name);
+    let status = try_with!(
+        Command::new(MAN_EXECUTABLE)
+            .arg("nixos-generate-config")
+            .env("MANPATH", NIXOS_MANPAGES)
+            .status(),
+        "{}: failed to open man page",
+        app_name
+    );
+
     match status.code() {
-        Some(0) => {},
-        Some(code) => {
-            bail!("{}: man exited with {}", app_name, code);
-        },
-        None => {
-            bail!("{}: man was killed by signal", app_name);
-        }
-    };
-    Ok(())
+        Some(0) => Ok(()),
+        Some(code) => bail!("{}: man exited with {}", app_name, code),
+        None => bail!("{}: man was killed by signal", app_name),
+    }
 }
 
-
 pub fn run_app(args: &[String]) -> i32 {
-    let default_name: String = String::from("nixos-generate-config");
+    let default_name = String::from("nixos-generate-config");
     let app_name = args.get(0).unwrap_or(&default_name);
     let opts = match parse_options(&args[1..]) {
         Ok(opts) => opts,
         Err(err) => {
-            eprintln!("{}: {}", app_name, err);
+            writeln!(io::stderr(), "{}: {}", app_name, err)
+                .expect("Failed to write error to stderr");
+
             return 1;
         }
     };
+
     if opts.show_help {
         if let Err(err) = show_help(app_name) {
-            eprintln!("{}: {}", app_name, err);
+            writeln!(io::stderr(), "{}: {}", app_name, err)
+                .expect("Failed to write error to stderr");
+
             return 1;
         }
-        return 0;
     }
-    return 0;
+
+    0
 }

--- a/nixos/modules/installer/tools/nixos-generate-config/src/main.rs
+++ b/nixos/modules/installer/tools/nixos-generate-config/src/main.rs
@@ -1,0 +1,7 @@
+use nixos_generate_config::run_app;
+
+pub fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    std::process::exit(run_app(&args))
+}

--- a/nixos/modules/installer/tools/nixos-generate-config/tests/main_test.rs
+++ b/nixos/modules/installer/tools/nixos-generate-config/tests/main_test.rs
@@ -1,11 +1,14 @@
-use std::env;
 use nixos_generate_config::run_app;
 
 #[test]
 fn it_shows_help() {
-    let args = vec![String::from("nixos-generate-config"), String::from("--help")];
-    // make man quite immediately
-    env::set_var("MANPAGER", "true");
+    let args = vec![
+        String::from("nixos-generate-config"),
+        String::from("--help"),
+    ];
+
+    // make man quit immediately
+    std::env::set_var("MANPAGER", "true");
 
     let res = run_app(&args);
     assert_eq!(res, 0);


### PR DESCRIPTION
    nixos-generate-config: 2018-ify, rustfmt, use write!

    Also dropped some unnecessary/one-off imports (such as `use
    std::string::String`, which is included in the default prelude).

    For rationale around using write{,ln}! over print{,ln}!, see
    https://github.com/BurntSushi/advent-of-code/issues/17 -- print! and
    friends can panic.

&nbsp;

    nixos-generate-config: move binary to main.rs

    I don't see us needing any additional binaries for this, so a folder
    dedicated to a single binary seems weird.

&nbsp;

    nixos-generate-config: don't show binary name multiple times

    Because we print the binary name and the relevant error when e.g.
    `show_help()` or `parse_options()` errors out, we don't need to add the
    binary name to the error message until we're ready to print it.
